### PR TITLE
Simplify shortcut creation and efficient hash extraction from shortcut file

### DIFF
--- a/recovery.py
+++ b/recovery.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if args.hash:
-        print(f"[+] Recovering file with hash: {args.hash}\m")
+        print(f"[+] Recovering file with hash: {args.hash}\n")
 
     elif args.link_file_path:
         if not (os.path.isfile(args.link_file_path)
@@ -122,8 +122,8 @@ if __name__ == "__main__":
 
         try:
             lnk = pylnk3.parse(args.link_file_path)
-            if lnk.arguments and lnk.arguments.startswith("--hash"):
-                args.hash = lnk.arguments.split()[1]
+            if lnk.arguments and lnk.arguments.split()[-2].startswith("--hash"):
+                args.hash = lnk.arguments.split()[-1]
             else:
                 raise ValueError("Invalid or missing hash in shortcut.")
 


### PR DESCRIPTION
### Overview

This pull request uses a simplified shortcut creation method with `pylnk3`, recovers the hidden file if shortcut creation fails, and corrects the hash extraction from the shortcut file.

### Changes

* **hiding.py:**
    * Uses `pylnk3` for shortcut creation.
    * Recovers the hidden file if an error occurs during shortcut creation.
* **recovery.py:** Efficiently extracts the hash from the end of the list of shortcut arguments.

### Purpose

In the `make_shortcut()` method of `hiding.py`, if an error occurs during shortcut creation, the hidden file is not recovered. This pull request addresses this issue. Additionally, `pylnk3` simplifies the shortcut creation method.

### Testing

* Verified the recovery of the hidden file if shortcut creation encounters an error.
* Verified the correct extraction of the hash from the shortcut file.

### Notes

Please review these changes and provide feedback before merging.