### PR TITLE
Improve File Hiding & Recovery, and Add 'Recover All' to Directory Context Menus

### DIFF
--- a/Remove-RightClick.bat
+++ b/Remove-RightClick.bat
@@ -6,5 +6,6 @@ echo.
 
 reg delete "HKEY_CLASSES_ROOT\*\shell\Hide File" /f
 reg delete "HKEY_CLASSES_ROOT\Lnkfile\shell\Recover File" /f
+reg delete "HKEY_CLASSES_ROOT\Directory\Background\shell\Recover All" /f
 
 pause

--- a/Set-RightClick.bat
+++ b/Set-RightClick.bat
@@ -13,4 +13,7 @@ reg add "HKEY_CLASSES_ROOT\*\shell\Hide File\command" /t REG_SZ /v "" /d "\"%hid
 reg add "HKEY_CLASSES_ROOT\Lnkfile\shell\Recover File" /t REG_SZ /v "" /d "Recover File (Extract File)" /f
 reg add "HKEY_CLASSES_ROOT\Lnkfile\shell\Recover File\command" /t REG_SZ /v "" /d "\"%recovery_path%\" --link_file_path \"%%1\"" /f
 
+reg add "HKEY_CLASSES_ROOT\Directory\Background\shell\Recover All" /t REG_SZ /v "" /d "Recover All (Extract All Files)" /f
+reg add "HKEY_CLASSES_ROOT\Directory\Background\shell\Recover All\command" /t REG_SZ /v "" /d "\"%recovery_path%\" --all" /f
+
 pause 

--- a/hiding.py
+++ b/hiding.py
@@ -93,10 +93,13 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
         print(f"[-] Failed to hide {file_path}. No application found for the extension: {ext}.")
         return None
 
-    new_name = name_gen(MAPPING_DB.hidden_ext_list)
     if not hidden_dir_key:
         hidden_dir_key = random.choice(list(MAPPING_DB.hidden_dir_dict.keys()))
-    hidden_file_path = os.path.join(MAPPING_DB.hidden_dir_dict.get(hidden_dir_key), new_name)
+    while True:
+        new_name = name_gen(MAPPING_DB.hidden_ext_list)
+        hidden_file_path = os.path.join(MAPPING_DB.hidden_dir_dict.get(hidden_dir_key), new_name)
+        if not os.path.exists(hidden_file_path):
+            break    
     shortcut_path = f"{file_path}.lnk"
     hashed_name = hash_name(hidden_file_path)
 

--- a/recovery.py
+++ b/recovery.py
@@ -40,8 +40,14 @@ def recovery(hidden_file: str, mapping_dict: dict[str, str],
         if not original_file:
             raise ValueError(f"No mapping found for {hidden_file}.")
 
+        original_name, original_ext = os.path.splitext(original_file)
+        count = 1
+        while os.path.exists(original_file):
+            original_file = f"{original_name}({count}){original_ext}"
+            count += 1
+
         os.rename(hidden_file, original_file)
-        shortcut_path = f"{original_file}.lnk"
+        shortcut_path = f"{original_name}{original_ext}.lnk"
         if os.path.exists(shortcut_path):
             os.remove(shortcut_path)
 


### PR DESCRIPTION
### Overview

This pull request improves the robustness of the file recovery process, handles failures in the hiding process for accidental `FileExistsError` exceptions, and enhances user experience by adding "**Recover All**" functionality to directory context menu options.

### Changes

* **recovery.py:**
    * Implements file existence checks during recovery to prevent `FileExistsError` exceptions. Recovered files are renamed with a counter (e.g., "original(1).txt") if necessary.
* **hiding.py:**
    * Ensures unique hidden file names are generated during the hiding process to avoid conflicts.
* **set-rightclick.bat:**
    * Adds a "Recover All" context menu option to directories in Windows Explorer and on the Desktop, allowing users to recover all hidden files with a single click.
* **remove-rightclick.py:**
    * Adds a command to remove the "Recover All" context menu option.

###   Purpose

If a file and a .lnk file with the same filename exist, recovering the .lnk file encounters a `FileExistsError` exception. This pull request addresses this issue by adding a counter value to the recovered file's name. Moreover, all hidden files can now be easily recovered using the "Recover All" option in the right-click menu of the Desktop or File Explorer.

###   Testing

* Verified that file recovery correctly handles existing files by creating copies with incremented counters.
* Verified that hidden files are created with unique names.
* Verified that the "Recover All" context menu option appears in directories and functions as expected.
* Verified that the "Recover All" context menu option is removed correctly.

###   Notes

Please review these changes and provide feedback before merging.