### PR TITLE
feat: Support cross-drive file hiding & recovery with administrative privileges

### DIFF
--- a/hiding.py
+++ b/hiding.py
@@ -13,6 +13,7 @@ import os
 import sys
 import json
 import random
+import shutil
 import argparse
 from dataclasses import dataclass
 
@@ -116,7 +117,12 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
     hashed_name = hash_name(hidden_file_path)
 
     try:
-        os.rename(file_path, hidden_file_path)
+        same_drive = True if os.path.splitdrive(file_path)[0] == os.path.splitdrive(hidden_file_path)[0] else False
+        if same_drive:
+            os.rename(file_path, hidden_file_path)
+        else:
+            shutil.copy2(file_path, hidden_file_path)
+            os.remove(file_path)
 
         # executable (for release)
         if getattr(sys, "frozen", False):
@@ -144,7 +150,11 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
     except (ValueError, OSError) as e:
         print(f"[-] Failed to hide {file_path}: {e}")
         if os.path.exists(hidden_file_path):
-            os.rename(hidden_file_path, file_path)
+            if same_drive:
+                os.rename(hidden_file_path, file_path)
+            else:
+                shutil.copy2(hidden_file_path, file_path)
+                os.remove(hidden_file_path)
         return None
 
 

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ if (Test-Path "dist") {
 }
 
 uv run pyinstaller -F hiding.py --uac-admin --manifest admin.manifest
-uv run pyinstaller -F recovery.py
+uv run pyinstaller -F recovery.py --uac-admin --manifest admin.manifest
 uv run pyinstaller -F linker.py --uac-admin --manifest admin.manifest
 echo "`n---------------------------------`n"
 

--- a/recovery.py
+++ b/recovery.py
@@ -12,6 +12,7 @@ Usage:
 import os
 import sys
 import json
+import shutil
 import argparse
 
 import pylnk3
@@ -46,7 +47,13 @@ def recovery(hidden_file: str, mapping_dict: dict[str, str],
             original_file = f"{original_name}({count}){original_ext}"
             count += 1
 
-        os.rename(hidden_file, original_file)
+        same_drive = True if os.path.splitdrive(hidden_file)[0] == os.path.splitdrive(original_file)[0] else False
+        if same_drive:
+            os.rename(hidden_file, original_file)
+        else:
+            shutil.copy2(hidden_file, original_file)
+            os.remove(hidden_file)
+
         shortcut_path = f"{original_name}{original_ext}.lnk"
         if os.path.exists(shortcut_path):
             os.remove(shortcut_path)


### PR DESCRIPTION
### Overview

This pull request enhances the project's functionality by adding support for cross-drive file hiding and recovery with administrative privileges, and embeds `admin.manifest` in `recovery.exe`.

### Changes

* **hiding.py:**
    * Implements cross-drive file hiding by replacing `os.rename` with `shutil.copy2` and `os.remove` when source and destination are on different drives.
    * Updates error handling to account for cross-drive operations in case of error in shortcut creation.
* **recovery.py:**
    * Implements cross-drive file recovery by replacing `os.rename` with `shutil.copy2` and `os.remove` when source and destination are on different drives.
* **install.ps1:**
    * Modifies the installation script to request administrative privileges by embedding `admin.manifest` in `recovery.exe`.

### Purpose

`os.rename()` fails to move files across drives. To handle this, the file is copied to the hidden path and then the original is removed. Using `shutil.copy2()` and `os.remove()` fixes this issue. Administrative privileges are required for the cross-drive recovery process, and embedding the `admin.manifest` file in `recovery.exe` ensures this.

### Testing

* Verified successful file hiding and recovery across different drives (e.g., C: to D:).
* Verified that `recovery.exe` prompts for administrative privileges during the recovery process for cross-drive operations.

### Notes

Please review these changes and provide feedback before merging.
