### PR TITLE
Handle 'PermissionError' and Ensure valid filenames

### DIFF
--- a/hiding.py
+++ b/hiding.py
@@ -86,6 +86,15 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
     Returns:
         Optional[str]: The path of the hidden file, or None if hiding failed.
     """
+
+    find_ext = os.path.basename(file_path).rfind(".")
+    if find_ext == -1:
+        print(f"[-] Failed to hide {file_path} : Missing extension in filename.")
+        return None
+    elif find_ext == 0:
+        print(f"[-] Failed to hide {file_path} : Invalid filename. Please rename it to a valid file name.")
+        return None
+
     ext = file_path.split(".")[-1].lower()
     if ext not in ext_icon_dict:
         print(f"[-] Failed to hide {file_path}. Extension {ext} is not supported.")
@@ -123,7 +132,14 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
         count += 1
 
     try:
-        shutil.move(file_path, hidden_file_path)
+        try:
+            os.rename(file_path, hidden_file_path)
+        except PermissionError as e:
+            print(f"[!] Failed to hide {file_path}: {e}")
+            print("[!] Please close the file and try again.")
+            sys.exit(1)
+        except OSError:
+            shutil.move(file_path, hidden_file_path)
 
         # executable (for release)
         if getattr(sys, "frozen", False):
@@ -151,7 +167,17 @@ def make_shortcut(file_path: str, ext_icon_dict: dict[str, str],
     except (ValueError, OSError) as e:
         print(f"[-] Failed to hide {file_path}: {e}")
         if os.path.exists(hidden_file_path):
-            shutil.move(hidden_file_path, file_path)
+            try:
+                os.rename(hidden_file_path, file_path)
+            except PermissionError as e:
+                print(f"[!] {e}")
+                print("[!] Please close the file and try again.")
+                sys.exit(1)
+            except OSError:
+                try:
+                    shutil.move(hidden_file_path, file_path)
+                except OSError as e:
+                    print(e)
         return None
 
 


### PR DESCRIPTION
### Overview

This pull request addresses potential `PermissionError` exceptions during the hiding and recovery processes when a file is in use by another process. It also ensures that only files with valid filenames are processed.

### Changes

* **`hiding.py`:**
    * Implemented checks to validate filenames (ensuring they have both a name and an extension).
    * Added error handling for `PermissionError` during the hiding process.
* **`recovery.py`:**
    * Implemented checks to validate filenames (ensuring they have both a name and an extension).
    * Added error handling for `PermissionError` during the recovery process.

### Purpose

`shutil.move` copies then deletes the source file and doesn't check if a file is in use before copying. If another process uses the source during hiding or recovery, it causes a `PermissionError` and the source is copied to destination but the source is not deleted, causing an `OSError`. To fix this `PermissionError` and support cross-drive operations, this pull request uses a combination of `os.rename` and `shutil.move`. `os.rename` is tried first and if it fails then file is in use or it's a cross-drive move. For cross-drive moves, `shutil.move` is used.

### Testing

* Confirmed that the application now only processes files with valid filenames (containing both a name and an extension).
* Verified that `PermissionError` exceptions are gracefully handled during both hiding and recovery processes when a file is in use.
* Tested and confirmed successful cross-drive hiding and recovery operations.

### Notes

Please review these changes and provide a feedback before merging.