### PR TITLE
Refactor: Centralize file operations in common_utils

### DIFF
--- a/recovery.py
+++ b/recovery.py
@@ -18,7 +18,7 @@ import argparse
 import pylnk3
 
 from modules.aes import AESCipher
-from modules.common_utils import get_dir_path
+from modules.common_utils import get_dir_path, move_file, validate_extension
 from modules.security_utils import hash_name, postprocessing, load_encrypted_data
 
 
@@ -35,9 +35,10 @@ def recovery(hidden_file: str, mapping_dict: dict[str, str],
     """
     try:
         if shortcut_file_path:
-            original_file = shortcut_file_path.removesuffix(".lnk")
-            while original_file.strip().endswith(" - Copy"):
-                original_file = original_file.removesuffix(" - Copy")
+            original_file = shortcut_file_path.removesuffix(".lnk").strip()
+            original_file = validate_extension(original_file)
+            if not original_file:
+                return None
         else:
             original_file = mapping_dict.get(hidden_file)
 
@@ -54,14 +55,9 @@ def recovery(hidden_file: str, mapping_dict: dict[str, str],
             original_file = f"{original_name}({count}){original_ext}"
             count += 1
 
-        try:
-            os.rename(hidden_file, original_file)
-        except PermissionError as e:
-            print(f"[!] Failed to hide {hidden_file}: {e}")
-            print("[!] Please close the file and try again.")
-            sys.exit(1)
-        except OSError:
-            shutil.move(hidden_file, original_file)
+        move_status = move_file(hidden_file, original_file)
+        if not move_status:
+            return None
 
         shortcut_path = f"{original_name}{original_ext}.lnk"
         if os.path.exists(shortcut_path):


### PR DESCRIPTION
### Overview

This pull request refactors the hiding and recovery functionality to utilize functions from the `common_utils` module.

### Changes

* **common\_utils.py:**
    * Added `move_file()` and `validate_ext()` methods.
* **hiding.py & recovery.py:**
    * Utilized the methods from `common_utils.py` for file moving and extension validation operations.

### Purpose

* **Reduce code duplication:** The file moving and extension validation logic was present in both the `hiding.py` and `recovery.py` files. This change centralizes that logic in `common_utils.py`.

### Testing

* Verified proper integration of `common_utils` functions within the hiding and recovery processes.
* Confirmed that file hiding and recovery operations function as expected after the refactor.

### Notes

Please review these changes and provide feedback before merging.
